### PR TITLE
feat: Make esaml_sp:decrypt_assertion/2 public

### DIFF
--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -13,7 +13,7 @@
 -include_lib("xmerl/include/xmerl.hrl").
 
 -export([setup/1, generate_authn_request/2, generate_authn_request/3, generate_metadata/1]).
--export([validate_assertion/2, validate_assertion/3]).
+-export([validate_assertion/2, validate_assertion/3, decrypt_assertion/2]).
 -export([generate_logout_request/3, generate_logout_request/4, generate_logout_response/3]).
 -export([validate_logout_request/2, validate_logout_response/2]).
 


### PR DESCRIPTION
So we can build dev tools to decrypt a payload without the validation part, without reinventing the whole decryption logic, instead getting (almost) the same behaviour as in prod.